### PR TITLE
Now using the parent UIElement if using the PlacementRectangle without a PlacementTarget

### DIFF
--- a/Gu.Wpf.Geometry/Balloon/BalloonBase.cs
+++ b/Gu.Wpf.Geometry/Balloon/BalloonBase.cs
@@ -224,7 +224,7 @@ namespace Gu.Wpf.Geometry
         {
             var hasTarget =
                 this.PlacementTarget?.IsVisible == true ||
-                !this.PlacementRectangle.IsEmptyOrZero();
+                !this.PlacementRectangle.IsEmpty;
 
             if (this.IsVisible && this.RenderSize.Width > 0 && hasTarget)
             {
@@ -235,23 +235,7 @@ namespace Gu.Wpf.Geometry
                 }
 
                 var selfRect = new Rect(new Point(0, 0).ToScreen(this), this.RenderSize).ToScreen(this);
-                var targetRect = Rect.Empty;
-
-                if (!this.PlacementRectangle.IsEmptyOrZero())
-                {
-                    if (this.PlacementTarget != null)
-                    {
-                        targetRect = this.PlacementRectangle.ToScreen(this.PlacementTarget).ToScreen(this);
-                    }
-                    else
-                    {
-                        targetRect = this.PlacementRectangle.ToScreen(Window.GetWindow(this)).ToScreen(this);
-                    }
-                }
-                else if (this.PlacementTarget != null)
-                {
-                    targetRect = new Rect(new Point(0, 0).ToScreen(this.PlacementTarget), this.PlacementTarget.RenderSize).ToScreen(this);
-                }
+                var targetRect = this.GetTargetRect();
 
                 var tp = this.PlacementOptions?.GetPointOnTarget(selfRect, targetRect);
                 if (tp == null || selfRect.Contains(tp.Value))
@@ -290,6 +274,33 @@ namespace Gu.Wpf.Geometry
         protected virtual void OnLayoutUpdated(object _, EventArgs __)
         {
             this.UpdateConnectorOffset();
+        }
+
+        protected virtual UIElement GetTarget()
+        {
+            return
+                this.PlacementTarget ??
+                this.GetVisualParent();
+        }
+
+        protected virtual Rect GetTargetRect()
+        {
+            var targetRect = Rect.Empty;
+
+            if (this.PlacementRectangle.IsEmpty)
+            {
+                targetRect = new Rect(new Point(0, 0).ToScreen(this.PlacementTarget), this.PlacementTarget.RenderSize).ToScreen(this);
+            }
+            else
+            {
+                var target = this.GetTarget();
+                if (target != null)
+                {
+                    targetRect = this.PlacementRectangle.ToScreen(target).ToScreen(this);
+                }
+            }
+
+            return targetRect;
         }
 
         private static void OnConnectorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/Gu.Wpf.Geometry/Balloon/EllipseBalloon.cs
+++ b/Gu.Wpf.Geometry/Balloon/EllipseBalloon.cs
@@ -77,7 +77,7 @@ namespace Gu.Wpf.Geometry
         {
             var hasTarget =
                 this.PlacementTarget?.IsVisible == true ||
-                !this.PlacementRectangle.IsEmptyOrZero();
+                !this.PlacementRectangle.IsEmpty;
 
             if (this.IsVisible && this.RenderSize.Width > 0 && hasTarget)
             {
@@ -88,25 +88,8 @@ namespace Gu.Wpf.Geometry
                 }
 
                 var selfRect = new Rect(new Point(0, 0).ToScreen(this), this.RenderSize).ToScreen(this);
+                var targetRect = this.GetTargetRect();
                 var ellipse = new Ellipse(selfRect);
-
-                var targetRect = Rect.Empty;
-
-                if (!this.PlacementRectangle.IsEmptyOrZero())
-                {
-                    if (this.PlacementTarget != null)
-                    {
-                        targetRect = this.PlacementRectangle.ToScreen(this.PlacementTarget).ToScreen(this);
-                    }
-                    else
-                    {
-                        targetRect = this.PlacementRectangle.ToScreen(this);
-                    }
-                }
-                else if (this.PlacementTarget != null)
-                {
-                    targetRect = new Rect(new Point(0, 0).ToScreen(this.PlacementTarget), this.PlacementTarget.RenderSize).ToScreen(this);
-                }
 
                 var tp = this.PlacementOptions?.GetPointOnTarget(selfRect, targetRect);
                 if (tp == null || ellipse.Contains(tp.Value))

--- a/Gu.Wpf.Geometry/Gu.Wpf.Geometry.csproj
+++ b/Gu.Wpf.Geometry/Gu.Wpf.Geometry.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Internals\Binding\CornerRadiusConverter.cs" />
     <Compile Include="Internals\Binding\CornerRadiusTopLeftConverter.cs" />
     <Compile Include="Internals\Binding\CornerRadiusTopRightConverter.cs" />
+    <Compile Include="Internals\DependencyObjectExt.cs" />
     <Compile Include="Internals\Constants.cs" />
     <Compile Include="GradientPath\GradientMode.cs" />
     <Compile Include="GradientPath\GradientPath+FigureGeometry.cs" />

--- a/Gu.Wpf.Geometry/Internals/DependencyObjectExt.cs
+++ b/Gu.Wpf.Geometry/Internals/DependencyObjectExt.cs
@@ -1,0 +1,27 @@
+namespace Gu.Wpf.Geometry
+{
+    using System.Windows;
+    using System.Windows.Media;
+
+    public static class DependencyObjectExt
+    {
+        public static UIElement GetVisualParent(this DependencyObject dependencyObject)
+        {
+            UIElement element = null;
+            DependencyObject reference = VisualTreeHelper.GetParent(dependencyObject);
+
+            while (reference != null)
+            {
+                element = reference as UIElement;
+                if (element != null)
+                {
+                    break;
+                }
+
+                reference = VisualTreeHelper.GetParent(reference);
+            }
+
+            return element;
+        }
+    }
+}

--- a/Gu.Wpf.Geometry/Internals/RectExt.cs
+++ b/Gu.Wpf.Geometry/Internals/RectExt.cs
@@ -34,14 +34,6 @@ namespace Gu.Wpf.Geometry
             return p.Closest(rect.TopLeft, rect.TopRight, rect.BottomRight, rect.BottomLeft);
         }
 
-        internal static bool IsEmptyOrZero(this Rect rect)
-        {
-            return
-                rect.IsEmpty ||
-                rect.Width <= 0 ||
-                rect.Height <= 0;
-        }
-
         internal static Rect ToScreen(this Rect rect, UIElement element)
         {
             if (PresentationSource.FromVisual(element) == null)

--- a/README.md
+++ b/README.md
@@ -154,8 +154,136 @@ Note: the connector is drawn outside the bounds of the element.
 
 ![connected balloon](http://i.imgur.com/wJBJACc.gif)
 
+##### With PlacementRectangle
+```xaml
+<Canvas>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="100" />
+            <RowDefinition Height="100" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="100" />
+            <ColumnDefinition Width="100" />
+            <ColumnDefinition Width="100" />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+        <ListBox x:Name="Placements"
+                 Grid.Row="0"
+                 Grid.RowSpan="3"
+                 Grid.Column="2"
+                 SelectedIndex="0">
+            <geometry:PlacementOptions>Auto</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto 5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto -5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Center 5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Center -5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Top Left</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Top Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Top Right</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Bottom Left</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Bottom Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Bottom Right</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Left</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Right</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Top</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Bottom</geometry:PlacementOptions>
+        </ListBox>
+
+        <geometry:BoxBalloon Grid.Row="1"
+                             Grid.Column="1"
+                             Margin="6"
+                             ConnectorAngle="45"
+                             CornerRadius="10"
+                             PlacementOptions="{Binding SelectedItem,
+                                                        ElementName=Placements}"
+                             PlacementRectangle="100, 50, 100, 10"
+                             Stroke="HotPink"
+                             StrokeThickness="4" />
+    </Grid>
+    <Rectangle x:Name="Target"
+               Canvas.Left="100"
+               Canvas.Top="50"
+               Width="100"
+               Height="10"
+               Fill="Gainsboro"
+               MouseLeftButtonDown="OnTargetMouseLeftDown" />
+</Canvas>
+```
+
+![connected balloon](http://i.imgur.com/wJBJACc.gif)
+
+##### With PlacementRectangle and PlacementTarget
+```xaml
+<Canvas>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="100" />
+            <RowDefinition Height="100" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="100" />
+            <ColumnDefinition Width="100" />
+            <ColumnDefinition Width="100" />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+        <ListBox x:Name="Placements"
+                 Grid.Row="0"
+                 Grid.RowSpan="3"
+                 Grid.Column="2"
+                 SelectedIndex="0">
+            <geometry:PlacementOptions>Auto</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto 5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto -5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Center 5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Center -5</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Top Left</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Top Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Top Right</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Bottom Left</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Bottom Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Bottom Right</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Center</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Left</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Right</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Top</geometry:PlacementOptions>
+            <geometry:PlacementOptions>Auto Bottom</geometry:PlacementOptions>
+        </ListBox>
+
+        <geometry:BoxBalloon Grid.Row="1"
+                             Grid.Column="1"
+                             Margin="6"
+                             ConnectorAngle="45"
+                             CornerRadius="10"
+                             PlacementOptions="{Binding SelectedItem,
+                                                        ElementName=Placements}"
+                             PlacementRectangle="0, 0, 100, 10"
+							 PlacementTarget={Binding ElementName=Target}
+                             Stroke="HotPink"
+                             StrokeThickness="4" />
+    </Grid>
+    <Rectangle x:Name="Target"
+               Canvas.Left="100"
+               Canvas.Top="50"
+               Width="100"
+               Height="10"
+               Fill="Gainsboro"
+               MouseLeftButtonDown="OnTargetMouseLeftDown" />
+</Canvas>
+```
+
+![connected balloon](http://i.imgur.com/wJBJACc.gif)
+
 ##### PlacementTarget
-Thge UIElement to connect the balloon to.
+The UIElement to connect the balloon to.
+
+##### PlacementRectangle
+The rectangle to connect the balloon to. If used with PlacementTarget, the rectangle coordinates are relative to it. If used alone, the coordinates are relative to the parent UIElement.
 
 ##### PlacementOptions
 Where on the connected element the connector should be attached.


### PR DESCRIPTION
- Was using the parent Window before. The new behavior is the same as the Popup class of WPF
- Added documentation for when using the PlacementRectangle